### PR TITLE
Feat(connect) Password rotation

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,42 @@
+std             = "ngx_lua"
+unused_args     = false
+redefined       = false
+max_line_length = false
+
+
+globals = {
+    --"_KONG",
+    --"kong",
+    --"ngx.IS_CLI",
+}
+
+
+not_globals = {
+    "string.len",
+    "table.getn",
+}
+
+
+ignore = {
+    --"6.", -- ignore whitespace warnings
+}
+
+
+exclude_files = {
+    --"spec/fixtures/invalid-module.lua",
+    --"spec-old-api/fixtures/invalid-module.lua",
+}
+
+
+--files["kong/plugins/ldap-auth/*.lua"] = {
+--    read_globals = {
+--        "bit.mod",
+--        "string.pack",
+--        "string.unpack",
+--    },
+--}
+
+
+-- files["spec/**/*.lua"] = {
+--     std = "ngx_lua+busted",
+-- }

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -231,15 +231,17 @@ do
     -- we wrap the conect method and not just the auth method because the auth
     -- method might close the connection upon auth failure. So to retry me must
     -- reconnect as well.
-    try_connect = function(self, pwd, usr)
+    try_connect = function(self, pwd, usr, db)
       self.password = pwd     -- set password to try in pg object
       self.user = usr         -- set username to try into pg object
+      self.database = db      -- set database name to try into pg object
       return self:_connect()  -- call original connect method
     end,
     connect = function(self)
       self._pwd_secret = self._pwd_secret or secret_cache(self.password)
       self._usr_secret = self._usr_secret or secret_cache(self.user)
-      local ok, err = Secrets:try(self.try_connect, self, self._pwd_secret, self._usr_secret)
+      self._database_secret = self._database_secret or secret_cache(self.database)
+      local ok, err = Secrets:try(self.try_connect, self, self._pwd_secret, self._usr_secret, self._database_secret)
       return ok, type(err) == "table" and tostring(err) or err
     end,
     settimeout = function(self, ...)


### PR DESCRIPTION
Requires "lua-resty-secrets" to handle secrets and rotation.

This was demoed Mar 4, 2021, see https://konghq.atlassian.net/wiki/spaces/KE/pages/3342337/Engineering+Demos

This branch requires `lua-resty-secrets` to be installed (version `0.3.0` minimum); https://github.com/Kong/lua-resty-secrets