### PR TITLE
fix(pgmoon) set the correct signature digest name when using ECDSA cert

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -371,9 +371,13 @@ do
               local server_cert = self.sock:getpeercertificate()
               pem, signature = server_cert:pem(), server_cert:getsignaturename()
             end
-            signature = signature:lower()
             if signature:match("^md5") or signature:match("^sha1") then
               signature = "sha256"
+            else
+              local objects = require("resty.openssl.objects")
+              local sigid = assert(objects.txt2nid(signature))
+              local digest_nid = assert(objects.find_sigid_algs(sigid))
+              signature = assert(objects.nid2table(digest_nid).sn)
             end
             cbind_data = assert(x509_digest(pem, signature))
           end


### PR DESCRIPTION
fix(pgmoon) set the correct signature digest name

When doing SSL connection to Postgres with ECDSA certificate, the
wrong signature digest name is used.

+ Fix: [FTI-3334](https://konghq.atlassian.net/browse/FTI-3334).
+ Related: https://github.com/Kong/kong-ee/pull/3393