### PR TITLE
fix(tlshandshake) check availability of `self.sock.tlshandshake` before call

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -867,7 +867,7 @@ do
         return nil, err
       end
       if t == MSG_TYPE.status then
-        if self.sock_type == "nginx" then
+        if self.sock_type == "nginx" and self.sock.tlshandshake then
           return self.sock:tlshandshake({
             verify = self.ssl_verify,
             client_cert = self.luasec_opts.cert,

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -544,7 +544,7 @@ class Postgres
     return nil, err unless t
 
     if t == MSG_TYPE.status
-      if @sock_type == "nginx"
+      if @sock_type == "nginx" and @sock.tlshandshake
         @sock\tlshandshake {
           verify: @ssl_verify,
           client_cert: @luasec_opts.cert,

--- a/spec/pgmoon_ssl_spec.moon
+++ b/spec/pgmoon_ssl_spec.moon
@@ -29,7 +29,7 @@ describe "pgmoon with server", ->
     assert pg\query "select * from information_schema.tables"
     pg\disconnect!
 
-  it "connects with ssl on ssl server (defaults to TLS v1.2)", ->
+  it "connects with ssl on ssl server (defaults to TLS v1.3)", ->
     pg = Postgres {
       database: DB
       port: PORT
@@ -38,22 +38,6 @@ describe "pgmoon with server", ->
       host: HOST
       ssl: true
       ssl_required: true
-    }
-
-    assert pg\connect!
-    assert pg\query "select * from information_schema.tables"
-    pg\disconnect!
-
-  it "connects with TLS v1.0 on ssl server", ->
-    pg = Postgres {
-      database: DB
-      port: PORT
-      user: USER
-      password: PASSWORD
-      host: HOST
-      ssl: true
-      ssl_required: true
-      ssl_version: "tlsv1"
     }
 
     assert pg\connect!
@@ -70,6 +54,22 @@ describe "pgmoon with server", ->
       ssl: true
       ssl_required: true
       ssl_version: "tlsv1_2"
+    }
+
+    assert pg\connect!
+    assert pg\query "select * from information_schema.tables"
+    pg\disconnect!
+
+  it "connects with TLS v1.3 on ssl server", ->
+    pg = Postgres {
+      database: DB
+      port: PORT
+      user: USER
+      password: PASSWORD
+      host: HOST
+      ssl: true
+      ssl_required: true
+      ssl_version: "tlsv1_3"
     }
 
     assert pg\connect!


### PR DESCRIPTION
When both `stream_listen` and Postgres SSL is enabled. Kong gateway `2.8.x.x` throws error as below.

```
2022/11/29 08:26:41 [error] 5590#0: *6685 stream [lua] init.lua:404: [cluster_events] poll() threw an error:
   /usr/local/share/lua/5.1/pgmoon/init.lua:875: attempt to call method 'tlshandshake' (a nil value), context: ngx.timer
```

Kong gateway `2.8.x.x` uses Pgmoon `2.2.0`.

As the Pgmoon `2.3.0` have high volume divergence from `2.2.0`, there is no way to bump. So we choose to patch `2.2.0`.

Refer to <https://github.com/Kong/pgmoon/commit/67dc4318721e84075b431273ceaea940016bb68e>

[FTI-3998]

[FTI-3998]: https://konghq.atlassian.net/browse/FTI-3998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ