### PR TITLE
fix(init) fix boringssl digest mapping

### DIFF
--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -415,7 +415,7 @@ do
               local server_cert = self.sock:getpeercertificate()
               pem, signature = server_cert:pem(), server_cert:getsignaturename()
             end
-            if signature:match("^md5") or signature:match("^sha1") then
+            if signature:match("^md5") or signature:match("^sha1") or signature:match("sha1$") or signature:match("sha256$") then
               signature = "sha256"
             else
               local objects = require("resty.openssl.objects")


### PR DESCRIPTION
When server (which runs with openssl) return digest name like `rsa-sha256`,
it won't be recognized as a valid NID text in boringssl. This patch maps such digest
directly.

Follow up of #20