### PR TITLE
release: 2.3.2.0 (kong internal version)

### DIFF
--- a/kong-pgmoon-2.3.2.0-1.rockspec
+++ b/kong-pgmoon-2.3.2.0-1.rockspec
@@ -1,9 +1,9 @@
 package = "kong-pgmoon"
-version = "2.3.1-1"
+version = "2.3.2.0-1"
 
 source = {
   url = "git+https://github.com/Kong/pgmoon.git",
-  tag = "2.3.1"
+  tag = "2.3.2.0" -- internal kong version adds an extra digit to the version
 }
 
 description = {

--- a/pgmoon/init.lua
+++ b/pgmoon/init.lua
@@ -14,7 +14,7 @@ if ngx then
 end
 local unpack = table.unpack or unpack
 local DEBUG = false
-local VERSION = "2.3.1"
+local VERSION = "2.3.2.0"
 local _len
 _len = function(thing, t)
   if t == nil then

--- a/pgmoon/init.moon
+++ b/pgmoon/init.moon
@@ -23,7 +23,7 @@ unpack = table.unpack or unpack
 -- https://www.postgresql.org/docs/current/protocol-message-formats.html
 
 DEBUG = false
-VERSION = "2.3.1"
+VERSION = "2.3.2.0"
 
 _len = (thing, t=type(thing)) ->
   switch t


### PR DESCRIPTION
Release version 2.3.2.0. This adds an extra digit to distinguish from upstream versions.